### PR TITLE
Include nouuid mount option when mounting lvm snapshot

### DIFF
--- a/exl_create_snap
+++ b/exl_create_snap
@@ -66,7 +66,7 @@ for LV in ${APP_LVNAME} ; do
   fi
   mkdir -p ${BACKUPDIR}/${LV}_snap_${TODAY}
   mkdir -p ${MNTTDIR}/${LV}_snap_${TODAY}
-  mount /dev/${APP_VGNAME}/${LV}_snap_${TODAY} ${MNTTDIR}/${LV}_snap_${TODAY}
+  mount -o nouuid /dev/${APP_VGNAME}/${LV}_snap_${TODAY} ${MNTTDIR}/${LV}_snap_${TODAY}
   if [ $? -ne 0 ] ; then
     echo "Unable to mount snapshot of the ${LV} volume. Backup process halting."
     exit 1


### PR DESCRIPTION
To ensure the LVM snapshots can be mounted correctly within a RHEL7 system that is using an xfs filesystem, I needed to add the `-o nouuid` option to the mount command. 