### PR TITLE
If warnings/errors occur, send those messages as an email to devsupport

### DIFF
--- a/exl_create_snap
+++ b/exl_create_snap
@@ -44,7 +44,7 @@ for LV in ${APP_LVNAME} ; do
         fi
         lvremove -f /dev/${APP_VGNAME}/${SNAPNAME} > /dev/null 2>&1
         if [ $? -ne 0 ] ; then
-          echo "WARNING: Unable to remove lingering snapshot ${SNAPNAME}"
+          echo "WARNING: Unable to remove lingering snapshot ${SNAPNAME}" | mail -s "Voyager Backup WARNING: Unable to remove lingering snapshot" lib_devsupport@library.ucla.edu
         fi
       fi
     done
@@ -52,14 +52,14 @@ for LV in ${APP_LVNAME} ; do
 
   lvcreate -L${LVSIZE} -s -n ${LV}_snap_${TODAY} /dev/${APP_VGNAME}/${LV} > /dev/null 2>&1
   if [ $? -ne 0 ] ; then
-    echo "Unable to create snapshot of the ${LV} volume. Backup process halting."
+    echo "Unable to create snapshot of the ${LV} volume. Backup process halting." | mail -s "Voyager Backup ERROR: Unable to create snapshot" lib_devsupport@library.ucla.edu
     exit 1
   fi
   mkdir -p ${BACKUPDIR}/${LV}_snap_${TODAY}
   mkdir -p ${MNTTDIR}/${LV}_snap_${TODAY}
   mount -o nouuid /dev/${APP_VGNAME}/${LV}_snap_${TODAY} ${MNTTDIR}/${LV}_snap_${TODAY}
   if [ $? -ne 0 ] ; then
-    echo "Unable to mount snapshot of the ${LV} volume. Backup process halting."
+    echo "Unable to mount snapshot of the ${LV} volume. Backup process halting." | mail -s "Voyager Backup ERROR: Unable to mount snapshot" lib_devsupport@library.ucla.edu
     exit 1
   fi
 done

--- a/exl_snap_backup
+++ b/exl_snap_backup
@@ -34,7 +34,7 @@ for LV in ${APP_LVNAME} ; do
   rsync -r -l -g -o -p -t -H -q --links --inplace \
     ${MNTTDIR}/${LV}_snap_${TODAY}/ ${BACKUPDIR}/${LV}_snap_${TODAY} > /dev/null 2>&1
   if [ $? -ne 0 ] ; then
-    echo "Copy of ${LV}_snap_${TODAY} snapshot to ${BACKUPDIR}/${LV}_snap_${TODAY} failed. Backup process halting."
+    echo "Copy of ${LV}_snap_${TODAY} snapshot to ${BACKUPDIR}/${LV}_snap_${TODAY} failed. Backup process halting." | mail -s "Voyager Backup ERROR: Copy of snapshot failed" lib_devsupport@library.ucla.edu
     exit 1
   fi
 
@@ -42,6 +42,6 @@ for LV in ${APP_LVNAME} ; do
   rm -rf ${MNTTDIR}/${LV}_snap_${TODAY}
   lvremove -f /dev/${APP_VGNAME}/${LV}_snap_${TODAY} > /dev/null 2>&1
   if [ $? -ne 0 ] ; then
-    echo "WARNING: Unable to remove snapshot ${LV}_snap_${TODAY}"
+    echo "WARNING: Unable to remove snapshot ${LV}_snap_${TODAY}" | mail -s "Voyager Backup WARNING: Unable to remove snapshot" lib_devsupport@library.ucla.edu
   fi
 done


### PR DESCRIPTION
I am including modifications to these scripts to notify the devsupport team if warnings or errors occur during back-up processing.

If an error condition occurs, the output of the respective `echo` commands is piped to `mail` and sent to the devsupport team mail alias. 